### PR TITLE
Fixed makeKvp method

### DIFF
--- a/geojson-to-wfst-2-cjs.js
+++ b/geojson-to-wfst-2-cjs.js
@@ -477,7 +477,7 @@ function Update(features, params = {}) {
    * feature. There is currently no way to input `action,` since wfs:Update's
    * default action, 'replace', is sufficient.
    */
-  const makeKvp = (prop, val, action) => wfs('Property', {}, wfs('ValueReference', { action }, prop) + (val == undefined ? wfs('Value', {}, val) : ''));
+  const makeKvp = (prop, val, action) => wfs('Property', {}, wfs('ValueReference', { action }, prop) + (val !== undefined ? wfs('Value', {}, val) : ''));
   if (params.properties) {
     let { handle, inputFormat, filter, typeName, whitelist } = params;
     let { srsName, ns, layer, geometry_name } = unpack(features[0] || {}, params, 'srsName', 'ns', 'layer', 'geometry_name');

--- a/geojson-to-wfst-2-es6.js
+++ b/geojson-to-wfst-2-es6.js
@@ -274,7 +274,7 @@ function Update(features, params={}){
   const makeKvp = (prop, val, action) => wfs(
     'Property', {},
     wfs('ValueReference', {action}, prop) +
-      (val == undefined ? wfs('Value', {}, val): '')
+      (val !== undefined ? wfs('Value', {}, val): '')
   );
   if (params.properties){
     let {handle, inputFormat, filter, typeName, whitelist} = params;


### PR DESCRIPTION
The makeKvp method did not include property values into update requests due to an error within the conditional ternary operator that is intentionally used to exclude the value parameter if the value equals undefined. I fixed the issue to make the method work as expected. Please accept this pull request after shortly reviewing it to fix the issue.